### PR TITLE
Add forgotten dependencies, export-default-from case

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -138,6 +138,15 @@
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.1.3.tgz",
       "integrity": "sha512-gqmspPZOMW3MIRb9HlrnbZHXI1/KHTOroBwN1NcLL6pWxzqzEKGvRTq0W/PxS45OtQGbaFikSQpkS5zbnsQm2w=="
     },
+    "@babel/plugin-proposal-export-default-from": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-default-from/-/plugin-proposal-export-default-from-7.2.0.tgz",
+      "integrity": "sha512-NVfNe7F6nsasG1FnvcFxh2FN0l04ZNe75qTOAVOILWPam0tw9a63RtT/Dab8dPjedZa4fTQaQ83yMMywF9OSug==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-export-default-from": "^7.2.0"
+      }
+    },
     "@babel/plugin-syntax-async-generators": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.0.0.tgz",
@@ -150,6 +159,14 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.0.0.tgz",
       "integrity": "sha512-Gt9xNyRrCHCiyX/ZxDGOcBnlJl0I3IWicpZRC4CdC0P5a/I07Ya2OAMEBU+J7GmRFVmIetqEYRko6QYRuKOESw==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-syntax-export-default-from": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-export-default-from/-/plugin-syntax-export-default-from-7.2.0.tgz",
+      "integrity": "sha512-c7nqUnNST97BWPtoe+Ssi+fJukc9P9/JMZ71IOMNQWza2E+Psrd46N6AEvtw6pqK+gt7ChjXyrw4SPDO79f3Lw==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -661,7 +678,6 @@
       "version": "1.11.3",
       "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.3.tgz",
       "integrity": "sha512-exDi1BYWB/6raKHmDTCicQfTkqwN5fioMFV4j8BsfMU4R2DK/QfZfK7kOVkmWCNANf0snkBzqGqAJBao9gZMdQ==",
-      "dev": true,
       "requires": {
         "resolve": "1.1.7"
       },
@@ -669,8 +685,7 @@
         "resolve": {
           "version": "1.1.7",
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-          "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
-          "dev": true
+          "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
         }
       }
     },
@@ -3354,9 +3369,9 @@
       "dev": true
     },
     "path-parse": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
     },
     "path-platform": {
       "version": "0.11.15",
@@ -3617,11 +3632,11 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz",
-      "integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.9.0.tgz",
+      "integrity": "sha512-TZNye00tI67lwYvzxCxHGjwTNlUV70io54/Ed4j6PscB8xVfuBJpRenI/o6dVk0cY0PYTY27AgCoGGxRnYuItQ==",
       "requires": {
-        "path-parse": "^1.0.5"
+        "path-parse": "^1.0.6"
       }
     },
     "resp-modifier": {
@@ -4100,6 +4115,17 @@
         "resumer": "~0.0.0",
         "string.prototype.trim": "~1.1.2",
         "through": "~2.3.8"
+      },
+      "dependencies": {
+        "resolve": {
+          "version": "1.7.1",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz",
+          "integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
+          "dev": true,
+          "requires": {
+            "path-parse": "^1.0.5"
+          }
+        }
       }
     },
     "term-color": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -171,6 +171,14 @@
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
+    "@babel/plugin-syntax-jsx": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.2.0.tgz",
+      "integrity": "sha512-VyN4QANJkRW6lDBmENzRszvZf3/4AXaj9YR7GwrWeeN9tEBPuXbmDYVU9bYBN0D70zCWVwUy0HWq2553VCb6Hw==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
     "@babel/plugin-syntax-object-rest-spread": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.0.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,15 @@
         "trim-right": "^1.0.1"
       }
     },
+    "@babel/helper-builder-react-jsx": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.0.0.tgz",
+      "integrity": "sha512-ebJ2JM6NAKW0fQEqN8hOLxK84RbRz9OkUhGS/Xd5u56ejMfVbayJ4+LykERZCOUM6faa6Fp3SZNX3fcT16MKHw==",
+      "requires": {
+        "@babel/types": "^7.0.0",
+        "esutils": "^2.0.0"
+      }
+    },
     "@babel/helper-function-name": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
@@ -195,6 +204,24 @@
         "@babel/helper-module-transforms": "^7.1.0",
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/helper-simple-access": "^7.1.0"
+      }
+    },
+    "@babel/plugin-transform-react-display-name": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.2.0.tgz",
+      "integrity": "sha512-Htf/tPa5haZvRMiNSQSFifK12gtr/8vwfr+A9y69uF0QcU77AVu4K7MiHEkTxF7lQoHOL0F9ErqgfNEAKgXj7A==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-react-jsx": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.2.0.tgz",
+      "integrity": "sha512-h/fZRel5wAfCqcKgq3OhbmYaReo7KkoJBpt8XnvpS7wqaNMqtw5xhxutzcm35iMUWucfAdT/nvGTsWln0JTg2Q==",
+      "requires": {
+        "@babel/helper-builder-react-jsx": "^7.0.0",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-jsx": "^7.2.0"
       }
     },
     "@babel/template": {
@@ -3138,9 +3165,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
-      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
+      "integrity": "sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw==",
       "dev": true,
       "optional": true
     },

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
   },
   "dependencies": {
     "@babel/core": "^7.1.2",
+    "@babel/plugin-proposal-class-properties": "^7.3.4",
+    "@babel/plugin-proposal-decorators": "^7.3.0",
     "@babel/plugin-proposal-export-default-from": "^7.2.0",
     "@babel/plugin-syntax-async-generators": "^7.0.0",
     "@babel/plugin-syntax-dynamic-import": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@babel/plugin-proposal-export-default-from": "^7.2.0",
     "@babel/plugin-syntax-async-generators": "^7.0.0",
     "@babel/plugin-syntax-dynamic-import": "^7.0.0",
+    "@babel/plugin-syntax-jsx": "^7.2.0",
     "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
     "@babel/plugin-transform-modules-commonjs": "^7.1.0",
     "babel-plugin-import-to-require": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "@babel/plugin-syntax-jsx": "^7.2.0",
     "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
     "@babel/plugin-transform-modules-commonjs": "^7.1.0",
+    "@babel/plugin-transform-react-display-name": "^7.2.0",
+    "@babel/plugin-transform-react-jsx": "^7.2.0",
     "babel-plugin-import-to-require": "^1.0.0",
     "browser-resolve": "^1.11.3",
     "cached-path-relative": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -11,14 +11,17 @@
   },
   "dependencies": {
     "@babel/core": "^7.1.2",
+    "@babel/plugin-proposal-export-default-from": "^7.2.0",
     "@babel/plugin-syntax-async-generators": "^7.0.0",
     "@babel/plugin-syntax-dynamic-import": "^7.0.0",
     "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
     "@babel/plugin-transform-modules-commonjs": "^7.1.0",
     "babel-plugin-import-to-require": "^1.0.0",
+    "browser-resolve": "^1.11.3",
     "cached-path-relative": "^1.0.1",
     "concat-stream": "^1.6.2",
     "duplexer2": "^0.1.4",
+    "resolve": "^1.9.0",
     "through2": "^2.0.3"
   },
   "devDependencies": {

--- a/transform.js
+++ b/transform.js
@@ -14,6 +14,8 @@ const pluginImportToRequire = require('babel-plugin-import-to-require');
 const pluginSyntaxRestSpread = require('@babel/plugin-syntax-object-rest-spread');
 const pluginSyntaxGenerator = require('@babel/plugin-syntax-async-generators');
 const pluginSyntaxJSX = require('@babel/plugin-syntax-jsx');
+const pluginReactJSX = require('@babel/plugin-transform-react-jsx');
+const pluginReactDisplayName = require('@babel/plugin-transform-react-display-name');
 
 module.exports = createTransform();
 module.exports.createTransform = createTransform;
@@ -53,6 +55,8 @@ function createTransform (babelOpts = {}) {
         babelrc: false,
         sourceMaps: 'inline',
         plugins: [
+          pluginReactJSX,
+          pluginReactDisplayName,
           pluginSyntaxRestSpread,
           pluginSyntaxJSX,
           pluginSyntaxGenerator,

--- a/transform.js
+++ b/transform.js
@@ -13,6 +13,7 @@ const pluginImportToRequire = require('babel-plugin-import-to-require');
 // Gotta add these as well so babel doesn't bail out when it sees new syntax
 const pluginSyntaxRestSpread = require('@babel/plugin-syntax-object-rest-spread');
 const pluginSyntaxGenerator = require('@babel/plugin-syntax-async-generators');
+const pluginSyntaxJSX = require('@babel/plugin-syntax-jsx');
 
 module.exports = createTransform();
 module.exports.createTransform = createTransform;
@@ -53,6 +54,7 @@ function createTransform (babelOpts = {}) {
         sourceMaps: 'inline',
         plugins: [
           pluginSyntaxRestSpread,
+          pluginSyntaxJSX,
           pluginSyntaxGenerator,
           plainImports.length > 0
             ? [ pluginImportToRequire, { modules: plainImports } ]

--- a/transform.js
+++ b/transform.js
@@ -5,6 +5,8 @@ const path = require('path');
 const concat = require('concat-stream');
 const duplexer = require('duplexer2');
 
+const pluginClassProperties = require('@babel/plugin-proposal-class-properties');
+const pluginDecorators = require('@babel/plugin-proposal-decorators');
 const pluginDynamicImport = require('@babel/plugin-syntax-dynamic-import');
 const pluginCJS = require('@babel/plugin-transform-modules-commonjs');
 const pluginExportDefaultFrom = require('@babel/plugin-proposal-export-default-from');
@@ -55,6 +57,8 @@ function createTransform (babelOpts = {}) {
         babelrc: false,
         sourceMaps: 'inline',
         plugins: [
+          [pluginDecorators, {legacy: true}],
+          [pluginClassProperties, {loose: true}],
           pluginReactJSX,
           pluginReactDisplayName,
           pluginSyntaxRestSpread,

--- a/transform.js
+++ b/transform.js
@@ -7,6 +7,7 @@ const duplexer = require('duplexer2');
 
 const pluginDynamicImport = require('@babel/plugin-syntax-dynamic-import');
 const pluginCJS = require('@babel/plugin-transform-modules-commonjs');
+const pluginExportDefaultFrom = require('@babel/plugin-proposal-export-default-from');
 const pluginImportToRequire = require('babel-plugin-import-to-require');
 
 // Gotta add these as well so babel doesn't bail out when it sees new syntax
@@ -57,7 +58,8 @@ function createTransform (babelOpts = {}) {
             ? [ pluginImportToRequire, { modules: plainImports } ]
             : false,
           pluginDynamicImport,
-          pluginCJS
+          pluginExportDefaultFrom,
+          pluginCJS,
         ].filter(Boolean),
         filename: file
       });


### PR DESCRIPTION
Hello @mattdesl

This fixes forgotten dependencies `resolve`, `browser-resolve` and enables `export ... from ...` syntax.