### PR TITLE
Add missing `browser-resolve` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@babel/plugin-syntax-object-rest-spread": "^7.2.0",
     "@babel/plugin-transform-modules-commonjs": "^7.2.0",
     "babel-plugin-import-to-require": "^1.0.0",
+    "browser-resolve": "^1.11.3",
     "cached-path-relative": "^1.0.2",
     "concat-stream": "^1.6.2",
     "duplexer2": "^0.1.4",


### PR DESCRIPTION
This is a direct dependency. 

https://github.com/mattdesl/esmify/blob/d7e07e6d24198e873ee0e98e88f87112c7aab230/resolve.js#L1

It never failed probably because browserify installs it in the same `node_modules`


---

How to reproduce

1. install esmify locally
2. use global browserify from cli

```log
❯ browserify index.js -p esmify
internal/modules/cjs/loader.js:716
    throw err;
    ^

Error: Cannot find module 'browser-resolve'
Require stack:
- ./node_modules/esmify/resolve.js
- ./node_modules/esmify/esmify.js
- /usr/local/lib/node_modules/browserify/index.js
- /usr/local/lib/node_modules/browserify/bin/args.js
- /usr/local/lib/node_modules/browserify/bin/cmd.js
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:713:15)
    at Function.Module._load (internal/modules/cjs/loader.js:618:27)
    at Module.require (internal/modules/cjs/loader.js:771:19)
    at require (internal/modules/cjs/helpers.js:68:18)
    at Object.<anonymous> (./node_modules/esmify/resolve.js:1:24)
    at Module._compile (internal/modules/cjs/loader.js:868:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:879:10)
    at Module.load (internal/modules/cjs/loader.js:731:32)
    at Function.Module._load (internal/modules/cjs/loader.js:644:12)
    at Module.require (internal/modules/cjs/loader.js:771:19) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    './node_modules/esmify/resolve.js',
    './node_modules/esmify/esmify.js',
    '/usr/local/lib/node_modules/browserify/index.js',
    '/usr/local/lib/node_modules/browserify/bin/args.js',
    '/usr/local/lib/node_modules/browserify/bin/cmd.js'
  ]
}
```